### PR TITLE
Network stats sidebar changes in web explorer

### DIFF
--- a/components/Device/widgets/RewardsSheet.vue
+++ b/components/Device/widgets/RewardsSheet.vue
@@ -149,8 +149,7 @@
         loading.value = false
         showRewards.value = true
       })
-      .catch((e) => {
-        console.log(e)
+      .catch(() => {
         emit('loadingRewardsTab', false)
         loading.value = false
         showRewards.value = false

--- a/components/Device/widgets/RewardsSheet.vue
+++ b/components/Device/widgets/RewardsSheet.vue
@@ -51,7 +51,6 @@
   const { trackGAevent } = useGAevents()
   const remoteConfig = await fetchRemoteConfig()
   const mainnetShowFlag = ref<boolean>(remoteConfig.feat_mainnet._value === 'true')
-  const mainnetBannerText = ref<string>(`${remoteConfig.feat_mainnet_message._value}`)
   const loading = ref(false)
   // rewards stuff
   const totalStationRewards = ref('')
@@ -168,7 +167,9 @@
 <template>
   <div>
     <div class="py-5 px-2 pt-0">
-      <MainnetBanner v-if="mainnetShowFlag" :text="mainnetBannerText"></MainnetBanner>
+      <div class="mx-2 mt-2">
+        <MainnetBanner v-if="mainnetShowFlag"></MainnetBanner>
+      </div>
       <EmptyRewards v-if="emptyStateFlag && !loading" />
       <TotalStationRewards
         v-if="!emptyStateFlag && !loading && showRewards"

--- a/components/Device/widgets/RewardsWidgets/MainnetBanner.vue
+++ b/components/Device/widgets/RewardsWidgets/MainnetBanner.vue
@@ -12,29 +12,29 @@
   const remoteConfig = await fetchRemoteConfig()
   const mainnetBannerText = ref<string>(`${remoteConfig.feat_mainnet_message._value}`)
   const mainnetUrl = ref<string>(`${remoteConfig.feat_mainnet_url._value}`)
+  const computedBannerText = computed(() => {
+    return mainnetBannerText.value.replaceAll(/\n/g, '<br/>')
+  })
 </script>
 
 <template>
-  <VImg
-    :src="bannerBackground"
-    class="rounded-xl mb-4 d-flex justify-center align-center"
-    style="cursor: pointer"
-    @click="navigateTo(mainnetUrl, { open: { target: '_blank' } })"
-  >
-    <div
-      class="d-flex flex-column text-center align-center justify-center px-1"
-      :class="theme.current.value.dark ? `text-text` : 'text-top'"
-    >
+  <a :href="mainnetUrl" target="_blank" class="text-decoration-none">
+    <VImg :src="bannerBackground" class="rounded-xl mb-4 d-flex justify-center align-center">
       <div
-        :style="smBreakpoing ? { 'font-size': '1.5rem' } : { 'font-size': '1.75rem' }"
-        class="font-weight-bold"
+        class="d-flex flex-column text-center align-center justify-center px-1"
+        :class="theme.current.value.dark ? `text-text` : 'text-top'"
       >
-        <i class="fa-regular fa-hexagon-check"></i>
-        <span class="pl-2">Welcome to Mainnet!</span>
+        <div
+          :style="smBreakpoing ? { 'font-size': '1.5rem' } : { 'font-size': '1.75rem' }"
+          class="font-weight-bold"
+        >
+          <i class="fa-regular fa-hexagon-check"></i>
+          <span class="pl-2">Welcome to Mainnet!</span>
+        </div>
+        <div class="text-body-2 my-2 px-2">
+          <div v-html="computedBannerText" />
+        </div>
       </div>
-      <div class="text-body-2 my-2">
-        <div>{{ mainnetBannerText }}</div>
-      </div>
-    </div>
-  </VImg>
+    </VImg>
+  </a>
 </template>

--- a/components/Device/widgets/RewardsWidgets/MainnetBanner.vue
+++ b/components/Device/widgets/RewardsWidgets/MainnetBanner.vue
@@ -1,14 +1,7 @@
 <script setup lang="ts">
+  import { options } from 'joi'
   import { useTheme, useDisplay } from 'vuetify'
   import bannerBackground from '~/assets/bannerBackground.jpeg'
-
-  interface Props {
-    text?: string
-  }
-
-  const props = withDefaults(defineProps<Props>(), {
-    text: ''
-  })
 
   const theme = useTheme()
   const display = useDisplay()
@@ -16,13 +9,18 @@
     return display.smAndDown
   })
 
-  console.log()
+  const { fetchRemoteConfig } = useFirebase()
+  const remoteConfig = await fetchRemoteConfig()
+  const mainnetBannerText = ref<string>(`${remoteConfig.feat_mainnet_message._value}`)
+  const mainnetUrl = ref<string>(`${remoteConfig.feat_mainnet_url._value}`)
 </script>
 
 <template>
   <VImg
     :src="bannerBackground"
-    class="rounded-xl mb-4 d-flex justify-center align-center mx-2 mt-2"
+    class="rounded-xl mb-4 d-flex justify-center align-center"
+    style="cursor: pointer"
+    @click="navigateTo(mainnetUrl, { open: { target: '_blank' } })"
   >
     <div
       class="d-flex flex-column text-center align-center justify-center px-1"
@@ -32,10 +30,11 @@
         :style="smBreakpoing ? { 'font-size': '1.5rem' } : { 'font-size': '1.75rem' }"
         class="font-weight-bold"
       >
-        <i class="fa-regular fa-badge-check"></i> <span>Welcome to Mainnet!</span>
+        <i class="fa-regular fa-hexagon-check"></i>
+        <span class="pl-2">Welcome to Mainnet!</span>
       </div>
       <div class="text-body-2 my-2">
-        <div>{{ props.text }}</div>
+        <div>{{ mainnetBannerText }}</div>
       </div>
     </div>
   </VImg>

--- a/components/Device/widgets/RewardsWidgets/MainnetBanner.vue
+++ b/components/Device/widgets/RewardsWidgets/MainnetBanner.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-  import { options } from 'joi'
   import { useTheme, useDisplay } from 'vuetify'
   import bannerBackground from '~/assets/bannerBackground.jpeg'
 

--- a/components/Stats/Stats.vue
+++ b/components/Stats/Stats.vue
@@ -35,9 +35,11 @@
 
   // mainnet banner vars
   const { fetchRemoteConfig } = useFirebase()
-  // const remoteConfig = await fetchRemoteConfig()
+  const remoteConfig = await fetchRemoteConfig()
   // const mainnetShowFlag = ref<boolean>(remoteConfig.feat_mainnet._value === 'true')
   const mainnetShowFlag = ref(true)
+  const arbiscanRemoteDomain = ref<string>(remoteConfig.explorer_web_arbiscan_base_url._value)
+  console.log(arbiscanRemoteDomain.value)
   // data days vars
   let dataDaysChartData = reactive([])
   let dataDaysLastAndProgress = reactive({ lastValue: '0', progress: '0' })
@@ -109,7 +111,7 @@
         // calc 30 days total
         rewards30DaysTotal.value = calc30DaysTotal(response.tokens.allocated_per_day)
         // rewards last tx url
-        rewardsLastRunLink.value = `https://arbiscan.io/tx/${response.tokens.last_tx_hash}`
+        rewardsLastRunLink.value = `${arbiscanRemoteDomain.value}${response.tokens.last_tx_hash}`
         // pass monthly avg tokens
         avgMonthly.value = response.tokens.avg_monthly
         console.log(response)

--- a/components/Stats/Stats.vue
+++ b/components/Stats/Stats.vue
@@ -112,7 +112,7 @@
         rewardsLastRunLink.value = `https://arbiscan.io/tx/${response.tokens.last_tx_hash}`
         // pass monthly avg tokens
         avgMonthly.value = response.tokens.avg_monthly
-
+        console.log(response)
         // pass total supply
         wxmTokenTotalSupply.value = response.tokens.total_supply
         // pass daily minted

--- a/components/Stats/Stats.vue
+++ b/components/Stats/Stats.vue
@@ -35,10 +35,9 @@
 
   // mainnet banner vars
   const { fetchRemoteConfig } = useFirebase()
-  // const { trackGAevent } = useGAevents()
-  const remoteConfig = await fetchRemoteConfig()
+  // const remoteConfig = await fetchRemoteConfig()
   // const mainnetShowFlag = ref<boolean>(remoteConfig.feat_mainnet._value === 'true')
-  const mainnetShowFlag = true
+  const mainnetShowFlag = ref(true)
   // data days vars
   let dataDaysChartData = reactive([])
   let dataDaysLastAndProgress = reactive({ lastValue: '0', progress: '0' })
@@ -49,11 +48,13 @@
   let rewardsLastAndProgress = reactive({ lastValue: '0', progress: '0' })
   let rewardsChartLabels = reactive([])
   const rewards30DaysTotal = ref(0)
+  const rewardsLastRunLink = ref('')
   // shop card var
   const avgMonthly = ref(0)
   // wxm token vars
   const wxmTokenTotalSupply = ref(0)
   const wxmTokenDailyMinted = ref(0)
+  const wxmTokenCirculatingSupply = ref(0)
   // weather stations vars
   let weatherStationsOnboarded = reactive({})
   let weatherStationsClaimed = reactive({})
@@ -107,7 +108,8 @@
         rewardsChartLabels = calcChartLabels(response.tokens.allocated_per_day)
         // calc 30 days total
         rewards30DaysTotal.value = calc30DaysTotal(response.tokens.allocated_per_day)
-
+        // rewards last tx url
+        rewardsLastRunLink.value = `https://arbiscan.io/tx/${response.tokens.last_tx_hash}`
         // pass monthly avg tokens
         avgMonthly.value = response.tokens.avg_monthly
 
@@ -115,6 +117,8 @@
         wxmTokenTotalSupply.value = response.tokens.total_supply
         // pass daily minted
         wxmTokenDailyMinted.value = response.tokens.daily_minted
+        // pass circulating supply
+        wxmTokenCirculatingSupply.value = response.tokens.circulating_supply
 
         // pass weather station data
         weatherStationsOnboarded = response.weather_stations.onboarded
@@ -231,6 +235,7 @@
               :rewards-last-and-progress="rewardsLastAndProgress"
               :rewards-chart-labels="rewardsChartLabels"
               :rewards30-days-total="rewards30DaysTotal"
+              :rewardsLastRunLink="rewardsLastRunLink"
             />
             <!------ Shop card ------>
             <ShopCard :avg-monthly="avgMonthly" />
@@ -238,6 +243,7 @@
             <WXMToken
               :wxm-token-total-supply="wxmTokenTotalSupply"
               :wxm-token-daily-minted="wxmTokenDailyMinted"
+              :wxm-token-circulating-supply="wxmTokenCirculatingSupply"
             />
             <!-------------------- Weather station ------------------>
             <WeatherStations

--- a/components/Stats/Stats.vue
+++ b/components/Stats/Stats.vue
@@ -39,7 +39,6 @@
   // const mainnetShowFlag = ref<boolean>(remoteConfig.feat_mainnet._value === 'true')
   const mainnetShowFlag = ref(true)
   const arbiscanRemoteDomain = ref<string>(remoteConfig.explorer_web_arbiscan_base_url._value)
-  console.log(arbiscanRemoteDomain.value)
   // data days vars
   let dataDaysChartData = reactive([])
   let dataDaysLastAndProgress = reactive({ lastValue: '0', progress: '0' })
@@ -114,7 +113,6 @@
         rewardsLastRunLink.value = `${arbiscanRemoteDomain.value}${response.tokens.last_tx_hash}`
         // pass monthly avg tokens
         avgMonthly.value = response.tokens.avg_monthly
-        console.log(response)
         // pass total supply
         wxmTokenTotalSupply.value = response.tokens.total_supply
         // pass daily minted

--- a/components/Stats/Stats.vue
+++ b/components/Stats/Stats.vue
@@ -38,7 +38,6 @@
   const remoteConfig = await fetchRemoteConfig()
   // const mainnetShowFlag = ref<boolean>(remoteConfig.feat_mainnet._value === 'true')
   const mainnetShowFlag = ref(true)
-  const arbiscanRemoteDomain = ref<string>(remoteConfig.explorer_web_arbiscan_base_url._value)
   // data days vars
   let dataDaysChartData = reactive([])
   let dataDaysLastAndProgress = reactive({ lastValue: '0', progress: '0' })
@@ -49,13 +48,15 @@
   let rewardsLastAndProgress = reactive({ lastValue: '0', progress: '0' })
   let rewardsChartLabels = reactive([])
   const rewards30DaysTotal = ref(0)
-  const rewardsLastRunLink = ref('')
+  const rewardsLastRunUrl = ref('')
+  const rewardsContractUrl = ref('')
   // shop card var
   const avgMonthly = ref(0)
   // wxm token vars
   const wxmTokenTotalSupply = ref(0)
   const wxmTokenDailyMinted = ref(0)
   const wxmTokenCirculatingSupply = ref(0)
+  const wxmTokenContractUrl = ref('')
   // weather stations vars
   let weatherStationsOnboarded = reactive({})
   let weatherStationsClaimed = reactive({})
@@ -109,8 +110,10 @@
         rewardsChartLabels = calcChartLabels(response.tokens.allocated_per_day)
         // calc 30 days total
         rewards30DaysTotal.value = calc30DaysTotal(response.tokens.allocated_per_day)
-        // rewards last tx url
-        rewardsLastRunLink.value = `${arbiscanRemoteDomain.value}${response.tokens.last_tx_hash}`
+        // pass rewards last tx url
+        rewardsLastRunUrl.value = response.tokens.last_tx_hash_url
+        // pass rewards contract url
+        rewardsContractUrl.value = response.contracts.rewards_url
         // pass monthly avg tokens
         avgMonthly.value = response.tokens.avg_monthly
         // pass total supply
@@ -119,7 +122,8 @@
         wxmTokenDailyMinted.value = response.tokens.daily_minted
         // pass circulating supply
         wxmTokenCirculatingSupply.value = response.tokens.circulating_supply
-
+        // pass wxmToken contract url
+        wxmTokenContractUrl.value = response.contracts.token_url
         // pass weather station data
         weatherStationsOnboarded = response.weather_stations.onboarded
         weatherStationsClaimed = response.weather_stations.claimed
@@ -235,7 +239,8 @@
               :rewards-last-and-progress="rewardsLastAndProgress"
               :rewards-chart-labels="rewardsChartLabels"
               :rewards30-days-total="rewards30DaysTotal"
-              :rewardsLastRunLink="rewardsLastRunLink"
+              :rewards-last-run-url="rewardsLastRunUrl"
+              :rewards-contract-url="rewardsContractUrl"
             />
             <!------ Shop card ------>
             <ShopCard :avg-monthly="avgMonthly" />
@@ -244,6 +249,7 @@
               :wxm-token-total-supply="wxmTokenTotalSupply"
               :wxm-token-daily-minted="wxmTokenDailyMinted"
               :wxm-token-circulating-supply="wxmTokenCirculatingSupply"
+              :wxm-token-contract-url="wxmTokenContractUrl"
             />
             <!-------------------- Weather station ------------------>
             <WeatherStations

--- a/components/Stats/Stats.vue
+++ b/components/Stats/Stats.vue
@@ -36,8 +36,7 @@
   // mainnet banner vars
   const { fetchRemoteConfig } = useFirebase()
   const remoteConfig = await fetchRemoteConfig()
-  // const mainnetShowFlag = ref<boolean>(remoteConfig.feat_mainnet._value === 'true')
-  const mainnetShowFlag = ref(true)
+  const mainnetShowFlag = ref<boolean>(remoteConfig.feat_mainnet._value === 'true')
   // data days vars
   let dataDaysChartData = reactive([])
   let dataDaysLastAndProgress = reactive({ lastValue: '0', progress: '0' })

--- a/components/Stats/Stats.vue
+++ b/components/Stats/Stats.vue
@@ -4,6 +4,7 @@
   import dayjs from 'dayjs'
   import LottieComponent from '../common/LottieComponent.vue'
   import NoInternetComponent from '../common/NoInternetComponent.vue'
+  import MainnetBanner from '../Device/widgets/RewardsWidgets/MainnetBanner.vue'
   import CardHeader from './widgets/CardHeader.vue'
   import MobileHeader from './widgets/MobileHeader.vue'
   import DataDays from './widgets/DataDays.vue'
@@ -32,6 +33,12 @@
     'Server busy, site may have moved or you lost your dial-up Internet connection'
   )
 
+  // mainnet banner vars
+  const { fetchRemoteConfig } = useFirebase()
+  // const { trackGAevent } = useGAevents()
+  const remoteConfig = await fetchRemoteConfig()
+  // const mainnetShowFlag = ref<boolean>(remoteConfig.feat_mainnet._value === 'true')
+  const mainnetShowFlag = true
   // data days vars
   let dataDaysChartData = reactive([])
   let dataDaysLastAndProgress = reactive({ lastValue: '0', progress: '0' })
@@ -206,7 +213,11 @@
             />
           </div>
 
-          <div v-if="!loading && !showNoInternetComponent" class="pa-4">
+          <div
+            v-if="!loading && !showNoInternetComponent"
+            :class="display.smAndDown ? `pa-5` : `pa-4`"
+          >
+            <MainnetBanner v-if="mainnetShowFlag"></MainnetBanner>
             <!-------- Data days -------->
             <DataDays
               :data-days-chart-data="dataDaysChartData"

--- a/components/Stats/widgets/ContactCard.vue
+++ b/components/Stats/widgets/ContactCard.vue
@@ -23,7 +23,12 @@
 </script>
 
 <template>
-  <VCard class="pa-0 ma-0 mb-0 mt-4" style="border-radius: 16px" color="blueTint" elevation="4">
+  <VCard
+    :class="display.smAndDown ? `pa-0 mb-3 ` : `pa-0 mb-4`"
+    style="border-radius: 16px"
+    color="blueTint"
+    elevation="4"
+  >
     <VCardText class="pa-0 ma-0">
       <VRow class="ma-0 pa-0" align="center" justify="space-between">
         <VCol class="ma-0 pr-0 pt-2 pb-2" :class="display.smAndDown ? 'pl-3' : 'pl-4'" cols="8">

--- a/components/Stats/widgets/DataDays.vue
+++ b/components/Stats/widgets/DataDays.vue
@@ -49,9 +49,14 @@
 </script>
 
 <template>
-  <VSheet color="top" style="border-radius: 16px" class="mb-4" elevation="4">
-    <div class="pl-5 pt-3 pr-2 text-body-2 d-flex align-center justify-space-between">
-      <div style="font-size: 1.094rem; font-weight: 700" class="text-text">
+  <VSheet
+    color="top"
+    style="border-radius: 16px"
+    :class="display.smAndDown ? `mb-3` : `mb-4`"
+    elevation="4"
+  >
+    <div class="px-2 pt-2 text-body-2 d-flex align-center justify-space-between">
+      <div style="font-size: 1.094rem; font-weight: 700" class="text-text pl-2 pt-1">
         {{ weatherStationDaysCardTitle }}
       </div>
       <div

--- a/components/Stats/widgets/LastUpdatedFooter.vue
+++ b/components/Stats/widgets/LastUpdatedFooter.vue
@@ -28,7 +28,7 @@
 
 <template>
   <div
-    class="text-subtitle-2 text-right pt-4 text-text"
+    class="text-subtitle-2 text-right text-text"
     style="font-weight: 100; font-style: normal; line-height: 21px"
   >
     {{ calcedLastUpdated }}

--- a/components/Stats/widgets/MobileHeader.vue
+++ b/components/Stats/widgets/MobileHeader.vue
@@ -13,13 +13,13 @@
 </script>
 
 <template>
-  <div v-if="display.smAndDown" class="px-4 py-5 d-flex align-center">
+  <div v-if="display.smAndDown" class="pa-8 pb-3 d-flex align-center">
     <i
       class="fa fa-arrow-left text-primary mr-4"
       style="font-size: 1.2rem"
       @click="closeMobilePage"
     ></i>
-    <span class="ma-0 pa-0" style="font-size: 1.577rem; font-weight: 700">{{
+    <span class="ma-0 pa-0 font-weight-bold" style="font-size: 1.577rem">{{
       netStatsMobileHeaderText
     }}</span>
   </div>

--- a/components/Stats/widgets/Rewards.vue
+++ b/components/Stats/widgets/Rewards.vue
@@ -13,6 +13,7 @@
     }
     rewardsChartLabels?: string[]
     rewards30DaysTotal?: number
+    rewardsLastRunLink?: string
   }
 
   const props = withDefaults(defineProps<Props>(), {
@@ -22,7 +23,8 @@
       progress: '0'
     }),
     rewardsChartLabels: () => [],
-    rewards30DaysTotal: 0
+    rewards30DaysTotal: 0,
+    rewardsLastRunLink: ''
   })
 
   const { trackGAevent } = useGAevents()
@@ -74,18 +76,18 @@
       </div>
     </div>
     <div
+      class="px-2 text-primary font-weight-black d-flex align-center"
+      style="cursor: pointer"
+      @click="
+        navigateTo(arbiscanAddress, { open: { target: '_blank' } }),
+          trackGAevent('click_on_reward_contract_link')
+      "
       @mouseenter="trackGAevent('click_on_reward_contract_link')"
-      @click="trackGAevent('click_on_reward_contract_link')"
     >
-      <div
-        class="px-2 text-primary font-weight-black d-flex align-center"
-        style="cursor: pointer"
-        @click="navigateTo(arbiscanAddress, { open: { target: '_blank' } })"
-      >
-        <span class="pl-2 pr-1">{{ rewardsSubtitleLinkText }}</span>
-        <i class="fa-solid fa-arrow-up-right-from-square"></i>
-      </div>
+      <span class="pl-2 pr-1">{{ rewardsSubtitleLinkText }}</span>
+      <i class="fa-solid fa-arrow-up-right-from-square"></i>
     </div>
+
     <VRow class="ma-0 pa-0 pl-5 pt-6 d-flex pb-4 pr-7">
       <VCol class="ma-0 pa-0" cols="9">
         <VRow class="ma-0 pa-0">
@@ -136,27 +138,26 @@
         </VSheet>
       </VCol>
       <VCol class="pa-0 ma-0" cols="6">
-        <div
+        <VSheet
+          class="px-4 pb-3 pt-3 ma-0 ml-1"
+          color="layer1"
+          style="border-radius: 8px; cursor: pointer"
           @mouseenter="trackGAevent('click_on_reward_last_run')"
-          @click="trackGAevent('click_on_reward_last_run')"
+          @click="
+            trackGAevent('click_on_reward_last_run'),
+              navigateTo(props.rewardsLastRunLink, { open: { target: '_blank' } })
+          "
         >
-          <VSheet
-            class="px-4 pb-3 pt-3 ma-0 ml-1"
-            color="layer1"
-            style="border-radius: 8px; cursor: pointer"
-            @click="navigateTo('http://www.google.com', { open: { target: '_blank' } })"
-          >
-            <div class="d-flex justify-space-between align-center mb-4 text-caption">
-              <div class="tex-text">{{ rewardsCardLastRunText }}</div>
-              <i class="fa-solid fa-arrow-up-right-from-square"></i>
+          <div class="d-flex justify-space-between align-center mb-4 text-caption">
+            <div class="tex-text">{{ rewardsCardLastRunText }}</div>
+            <i class="fa-solid fa-arrow-up-right-from-square"></i>
+          </div>
+          <div :style="responsiveTextStyles">
+            <div class="text-rewardVeryHigh d-flex justify-start">
+              +{{ props.rewardsLastAndProgress.progress }}
             </div>
-            <div :style="responsiveTextStyles">
-              <div class="text-rewardVeryHigh d-flex justify-start">
-                +{{ props.rewardsLastAndProgress.progress }}
-              </div>
-            </div>
-          </VSheet>
-        </div>
+          </div>
+        </VSheet>
       </VCol>
     </VRow>
   </VSheet>

--- a/components/Stats/widgets/Rewards.vue
+++ b/components/Stats/widgets/Rewards.vue
@@ -13,7 +13,8 @@
     }
     rewardsChartLabels?: string[]
     rewards30DaysTotal?: number
-    rewardsLastRunLink?: string
+    rewardsLastRunUrl?: string
+    rewardsContractUrl?: string
   }
 
   const props = withDefaults(defineProps<Props>(), {
@@ -24,7 +25,8 @@
     }),
     rewardsChartLabels: () => [],
     rewards30DaysTotal: 0,
-    rewardsLastRunLink: ''
+    rewardsLastRunUrl: '',
+    rewardsContractUrl: ''
   })
 
   const { trackGAevent } = useGAevents()
@@ -34,9 +36,6 @@
   const rewardsCardTotalText = ref('TOTAL')
   const rewardsCardLastRunText = ref('LAST RUN')
   const rewardsSubtitleLinkText = ref('View rewards contract on Arbiscan')
-  const arbiscanAddress = ref(
-    'https://arbiscan.io/address/0x3d5aA83d830398ad93fBAF98ee7079278b9DCD49'
-  )
   const tottalAllocatedRewardsMessage = ref(
     'Station owners are rewarded in $WXM for providing data to the WeatherXM Network.'
   )
@@ -80,7 +79,7 @@
       @click="trackGAevent('click_on_reward_contract_link')"
       @mouseenter="trackGAevent('click_on_reward_contract_link')"
     >
-      <a :href="arbiscanAddress" target="_blank" class="text-decoration-none">
+      <a :href="props.rewardsContractUrl" target="_blank" class="text-decoration-none">
         <span class="pl-2 pr-1">{{ rewardsSubtitleLinkText }}</span>
         <i class="fa-solid fa-arrow-up-right-from-square"></i>
       </a>
@@ -136,7 +135,7 @@
         </VSheet>
       </VCol>
       <VCol class="pa-0 ma-0" cols="6">
-        <a :href="props.rewardsLastRunLink" target="_blank" class="text-decoration-none">
+        <a :href="props.rewardsLastRunUrl" target="_blank" class="text-decoration-none">
           <VSheet
             class="px-4 pb-3 pt-3 ma-0 ml-1"
             color="layer1"

--- a/components/Stats/widgets/Rewards.vue
+++ b/components/Stats/widgets/Rewards.vue
@@ -31,7 +31,10 @@
   const rewardsCardLast30DaysText = ref('Last 30 Days')
   const rewardsCardTotalText = ref('TOTAL')
   const rewardsCardLastRunText = ref('LAST RUN')
-
+  const rewardsSubtitleLinkText = ref('View rewards contract on Arbiscan')
+  const arbiscanAddress = ref(
+    'https://arbiscan.io/address/0x3d5aA83d830398ad93fBAF98ee7079278b9DCD49'
+  )
   const tottalAllocatedRewardsMessage = ref(
     'Station owners are rewarded in $WXM for providing data to the WeatherXM Network.'
   )
@@ -49,9 +52,14 @@
 </script>
 
 <template>
-  <VSheet color="top" style="border-radius: 16px" class="mb-4" elevation="4">
-    <div class="pl-5 pt-3 pr-2 text-body-2 d-flex align-center justify-space-between">
-      <div style="font-size: 1.094rem; font-weight: 700" class="text-text">
+  <VSheet
+    color="top"
+    style="border-radius: 16px"
+    :class="display.smAndDown ? `mb-3` : `mb-4`"
+    elevation="4"
+  >
+    <div class="pl-2 pt-2 pr-2 mb-2 text-body-2 d-flex align-center justify-space-between">
+      <div style="font-size: 1.094rem; font-weight: 700" class="text-text pl-2 pt-1">
         {{ rewardsCardTitle }}
       </div>
       <div
@@ -63,6 +71,19 @@
           :container="'any'"
           :tooltip-title="tooltipTitle"
         />
+      </div>
+    </div>
+    <div
+      @mouseenter="trackGAevent('click_on_reward_contract_link')"
+      @click="trackGAevent('click_on_reward_contract_link')"
+    >
+      <div
+        class="px-2 text-primary font-weight-black d-flex align-center"
+        style="cursor: pointer"
+        @click="navigateTo(arbiscanAddress, { open: { target: '_blank' } })"
+      >
+        <span class="pl-2 pr-1">{{ rewardsSubtitleLinkText }}</span>
+        <i class="fa-solid fa-arrow-up-right-from-square"></i>
       </div>
     </div>
     <VRow class="ma-0 pa-0 pl-5 pt-6 d-flex pb-4 pr-7">
@@ -115,16 +136,27 @@
         </VSheet>
       </VCol>
       <VCol class="pa-0 ma-0" cols="6">
-        <VSheet class="px-4 pb-3 pt-3 ma-0 ml-1" color="layer1" style="border-radius: 8px">
-          <div class="d-flex justify-space-between align-center mb-4">
-            <div class="tex-text text-caption">{{ rewardsCardLastRunText }}</div>
-          </div>
-          <div :style="responsiveTextStyles">
-            <div class="text-rewardVeryHigh d-flex justify-start">
-              +{{ props.rewardsLastAndProgress.progress }}
+        <div
+          @mouseenter="trackGAevent('click_on_reward_last_run')"
+          @click="trackGAevent('click_on_reward_last_run')"
+        >
+          <VSheet
+            class="px-4 pb-3 pt-3 ma-0 ml-1"
+            color="layer1"
+            style="border-radius: 8px; cursor: pointer"
+            @click="navigateTo('http://www.google.com', { open: { target: '_blank' } })"
+          >
+            <div class="d-flex justify-space-between align-center mb-4 text-caption">
+              <div class="tex-text">{{ rewardsCardLastRunText }}</div>
+              <i class="fa-solid fa-arrow-up-right-from-square"></i>
             </div>
-          </div>
-        </VSheet>
+            <div :style="responsiveTextStyles">
+              <div class="text-rewardVeryHigh d-flex justify-start">
+                +{{ props.rewardsLastAndProgress.progress }}
+              </div>
+            </div>
+          </VSheet>
+        </div>
       </VCol>
     </VRow>
   </VSheet>

--- a/components/Stats/widgets/Rewards.vue
+++ b/components/Stats/widgets/Rewards.vue
@@ -77,15 +77,13 @@
     </div>
     <div
       class="px-2 text-primary font-weight-black d-flex align-center"
-      style="cursor: pointer"
-      @click="
-        navigateTo(arbiscanAddress, { open: { target: '_blank' } }),
-          trackGAevent('click_on_reward_contract_link')
-      "
+      @click="trackGAevent('click_on_reward_contract_link')"
       @mouseenter="trackGAevent('click_on_reward_contract_link')"
     >
-      <span class="pl-2 pr-1">{{ rewardsSubtitleLinkText }}</span>
-      <i class="fa-solid fa-arrow-up-right-from-square"></i>
+      <a :href="arbiscanAddress" target="_blank" class="text-decoration-none">
+        <span class="pl-2 pr-1">{{ rewardsSubtitleLinkText }}</span>
+        <i class="fa-solid fa-arrow-up-right-from-square"></i>
+      </a>
     </div>
 
     <VRow class="ma-0 pa-0 pl-5 pt-6 d-flex pb-4 pr-7">
@@ -138,26 +136,25 @@
         </VSheet>
       </VCol>
       <VCol class="pa-0 ma-0" cols="6">
-        <VSheet
-          class="px-4 pb-3 pt-3 ma-0 ml-1"
-          color="layer1"
-          style="border-radius: 8px; cursor: pointer"
-          @mouseenter="trackGAevent('click_on_reward_last_run')"
-          @click="
-            trackGAevent('click_on_reward_last_run'),
-              navigateTo(props.rewardsLastRunLink, { open: { target: '_blank' } })
-          "
-        >
-          <div class="d-flex justify-space-between align-center mb-4 text-caption">
-            <div class="tex-text">{{ rewardsCardLastRunText }}</div>
-            <i class="fa-solid fa-arrow-up-right-from-square"></i>
-          </div>
-          <div :style="responsiveTextStyles">
-            <div class="text-rewardVeryHigh d-flex justify-start">
-              +{{ props.rewardsLastAndProgress.progress }}
+        <a :href="props.rewardsLastRunLink" target="_blank" class="text-decoration-none">
+          <VSheet
+            class="px-4 pb-3 pt-3 ma-0 ml-1"
+            color="layer1"
+            style="border-radius: 8px"
+            @mouseenter="trackGAevent('click_on_reward_last_run')"
+            @click="trackGAevent('click_on_reward_last_run')"
+          >
+            <div class="d-flex justify-space-between align-center mb-4 text-caption">
+              <div class="tex-text">{{ rewardsCardLastRunText }}</div>
+              <i class="fa-solid fa-arrow-up-right-from-square"></i>
             </div>
-          </div>
-        </VSheet>
+            <div :style="responsiveTextStyles">
+              <div class="text-rewardVeryHigh d-flex justify-start">
+                +{{ props.rewardsLastAndProgress.progress }}
+              </div>
+            </div>
+          </VSheet>
+        </a>
       </VCol>
     </VRow>
   </VSheet>

--- a/components/Stats/widgets/ShopCard.vue
+++ b/components/Stats/widgets/ShopCard.vue
@@ -44,7 +44,12 @@
 </script>
 
 <template>
-  <VCard class="pa-0 ma-0 mb-4" style="border-radius: 16px" color="blueTint" elevation="4">
+  <VCard
+    :class="display.smAndDown ? `pa-0 ma-0 mb-3` : `pa-0 ma-0 mb-4`"
+    style="border-radius: 16px"
+    color="blueTint"
+    elevation="4"
+  >
     <VCardText class="pa-0 ma-0">
       <VRow class="ma-0 pa-0" align="center" justify="space-between">
         <VCol class="ma-0 pr-0 pt-2 pb-2 pl-4" cols="8">

--- a/components/Stats/widgets/WXMToken.vue
+++ b/components/Stats/widgets/WXMToken.vue
@@ -6,13 +6,13 @@
   interface Props {
     wxmTokenTotalSupply?: number
     wxmTokenDailyMinted?: number
-    wxmTokenCirculatingProgressBar?: number
+    wxmTokenCirculatingSupply?: number
   }
 
   const props = withDefaults(defineProps<Props>(), {
     wxmTokenDailyMinted: 0,
     wxmTokenTotalSupply: 0,
-    wxmTokenCirculatingProgressBar: 15
+    wxmTokenCirculatingSupply: 0
   })
 
   const { trackGAevent } = useGAevents()
@@ -43,7 +43,7 @@
   })
 
   const circulatingPercentage = computed(() => {
-    return props.wxmTokenCirculatingProgressBar
+    return (props.wxmTokenCirculatingSupply / props.wxmTokenTotalSupply) * 100
   })
 
   const nFormat = (number: number) => {
@@ -66,19 +66,20 @@
         {{ wxmTokenCardTitle }}
       </div>
     </div>
+
     <div
+      class="mb-3 text-primary font-weight-black d-flex align-center"
+      style="cursor: pointer"
+      @click="
+        trackGAevent('click_on_token_contract_link'),
+          navigateTo(wxmTokenSubtitleLink, { open: { target: '_blank' } })
+      "
       @mouseenter="trackGAevent('click_on_token_contract_link')"
-      @click="trackGAevent('click_on_token_contract_link')"
     >
-      <div
-        class="mb-3 text-primary font-weight-black d-flex align-center"
-        style="cursor: pointer"
-        @click="navigateTo(wxmTokenSubtitleLink, { open: { target: '_blank' } })"
-      >
-        <span class="pl-2 pr-1">{{ wxmTokenSubtitleLinkText }}</span>
-        <i class="fa-solid fa-arrow-up-right-from-square"></i>
-      </div>
+      <span class="pl-2 pr-1">{{ wxmTokenSubtitleLinkText }}</span>
+      <i class="fa-solid fa-arrow-up-right-from-square"></i>
     </div>
+
     <VRow class="px-0 pb-0 ma-0">
       <VCol class="pa-0 ma-0" cols="6">
         <VSheet class="px-4 pb-3 pt-3 ma-0 mr-1 h-100" color="layer1" style="border-radius: 8px">
@@ -114,7 +115,7 @@
             />
           </div>
           <div :style="responsiveTextStyles" class="mb-4">
-            {{ nFormat(props.wxmTokenDailyMinted) }}
+            {{ nFormat(props.wxmTokenCirculatingSupply) }}
           </div>
           <div>
             <v-progress-linear

--- a/components/Stats/widgets/WXMToken.vue
+++ b/components/Stats/widgets/WXMToken.vue
@@ -7,12 +7,14 @@
     wxmTokenTotalSupply?: number
     wxmTokenDailyMinted?: number
     wxmTokenCirculatingSupply?: number
+    wxmTokenContractUrl?: string
   }
 
   const props = withDefaults(defineProps<Props>(), {
     wxmTokenDailyMinted: 0,
     wxmTokenTotalSupply: 0,
-    wxmTokenCirculatingSupply: 0
+    wxmTokenCirculatingSupply: 0,
+    wxmTokenContractUrl: ''
   })
 
   const { trackGAevent } = useGAevents()
@@ -23,9 +25,6 @@
   const wxmTokenCardTotalText = ref('TOTAL SUPPLY')
   const wxmTokenCardCirculatingText = ref('CIRCULATING SUPPLY')
   const wxmTokenSubtitleLinkText = ref('View token contract on Etherscan')
-  const wxmTokenSubtitleLink = ref(
-    'https://etherscan.io/token/0xde654f497a563dd7a121c176a125dd2f11f13a83'
-  )
 
   const wxmTokenCardTotalSupplyTooltipTitle = ref('Total Supply')
   const wxmTokenCardTotalSupplyTooltipText = ref(
@@ -72,7 +71,7 @@
       @click="trackGAevent('click_on_token_contract_link')"
       @mouseenter="trackGAevent('click_on_token_contract_link')"
     >
-      <a :href="wxmTokenSubtitleLink" target="_blank" class="text-decoration-none">
+      <a :href="props.wxmTokenContractUrl" target="_blank" class="text-decoration-none">
         <span class="pl-2 pr-1">{{ wxmTokenSubtitleLinkText }}</span>
         <i class="fa-solid fa-arrow-up-right-from-square"></i
       ></a>

--- a/components/Stats/widgets/WXMToken.vue
+++ b/components/Stats/widgets/WXMToken.vue
@@ -1,24 +1,40 @@
 <script setup lang="ts">
-  import { useDisplay } from 'vuetify'
+  import { useDisplay, useTheme } from 'vuetify'
   import numberFormater from '../utils/numberFormater'
+  import TooltipComponent from '~/components/common/TooltipComponent.vue'
 
   interface Props {
     wxmTokenTotalSupply?: number
     wxmTokenDailyMinted?: number
+    wxmTokenCirculatingProgressBar?: number
   }
 
   const props = withDefaults(defineProps<Props>(), {
     wxmTokenDailyMinted: 0,
-    wxmTokenTotalSupply: 0
+    wxmTokenTotalSupply: 0,
+    wxmTokenCirculatingProgressBar: 15
   })
 
   const { trackGAevent } = useGAevents()
   const display = ref(useDisplay())
+  const theme = ref(useTheme())
   const wxmTokenCardTitle = ref('$WXM Token')
-  const wxmTokenCardContentText = ref('Deployed on Testnet -')
-  const wxmTokenCardContentLinkText = ref('Read more here')
+
   const wxmTokenCardTotalText = ref('TOTAL SUPPLY')
-  const wxmTokenCardMintedText = ref('DAILY MINTED')
+  const wxmTokenCardCirculatingText = ref('CIRCULATING SUPPLY')
+  const wxmTokenSubtitleLinkText = ref('View token contract on Etherscan')
+  const wxmTokenSubtitleLink = ref(
+    'https://etherscan.io/token/0xde654f497a563dd7a121c176a125dd2f11f13a83s'
+  )
+
+  const wxmTokenCardTotalSupplyTooltipTitle = ref('Total Supply')
+  const wxmTokenCardTotalSupplyTooltipText = ref(
+    'Total supply refers to the number of $WXM that have already been created and are either in circulation or locked.'
+  )
+  const wxmTokenCardCirculatingTooltipTitle = ref('Circulating Supply')
+  const wxmTokenCardCirculatingTooltipText = ref(
+    'Circulating supply refers to the number of $WXM that are publicly available and circulating in the market.'
+  )
 
   const responsiveTextStyles = computed(() => {
     return display.value.smAndDown
@@ -26,47 +42,53 @@
       : { 'font-size': '1.705rem', 'font-weight': 700 }
   })
 
-  const clickOnLink = () => {
-    // track GA event
-    trackGAevent('clickOnReadMoreForTokenomicsLink')
-    window.open('https://docs.weatherxm.com/tokenomics', '_blank')
-  }
+  const circulatingPercentage = computed(() => {
+    return props.wxmTokenCirculatingProgressBar
+  })
 
   const nFormat = (number: number) => {
     return numberFormater.nFormatter(number)
   }
-  const localizeNumber = (number: number) => {
-    return numberFormater.localizeNumberFormat(number)
-  }
 </script>
 
 <template>
-  <VSheet color="top" style="border-radius: 16px" class="mb-4" elevation="4">
+  <VSheet
+    color="top"
+    style="border-radius: 16px"
+    :class="display.smAndDown ? `pa-2 mb-3` : `pa-2 mb-4`"
+    elevation="4"
+  >
     <div
-      class="pl-5 pt-3 pr-6 text-body-2 d-flex align-center justify-space-between"
+      class="mb-2 text-body-2 d-flex align-center justify-space-between"
       style="line-height: 150%"
     >
-      <div style="font-size: 1.094rem; font-weight: 700">{{ wxmTokenCardTitle }}</div>
-    </div>
-
-    <div class="pl-5 pt-1 mb-3 text-body-2 d-flex align-center">
-      <div class="text-text" style="letter-spacing: normal">{{ wxmTokenCardContentText }}</div>
-
-      <div
-        class="d-flex align-center pl-1 text-decoration-none text-darkestBlue"
-        style="font-weight: 700; cursor: pointer; letter-spacing: normal"
-        @click="clickOnLink"
-      >
-        {{ wxmTokenCardContentLinkText }}
-        <i class="fa-solid fa-arrow-up-right-from-square pl-1" style="font-size: 11px"></i>
+      <div class="pl-2 pt-1 font-weight-bold" style="font-size: 1.094rem; font-weight: 700">
+        {{ wxmTokenCardTitle }}
       </div>
     </div>
-
-    <VRow class="px-2 pb-2 ma-0">
+    <div
+      @mouseenter="trackGAevent('click_on_token_contract_link')"
+      @click="trackGAevent('click_on_token_contract_link')"
+    >
+      <div
+        class="mb-3 text-primary font-weight-black d-flex align-center"
+        style="cursor: pointer"
+        @click="navigateTo(wxmTokenSubtitleLink, { open: { target: '_blank' } })"
+      >
+        <span class="pl-2 pr-1">{{ wxmTokenSubtitleLinkText }}</span>
+        <i class="fa-solid fa-arrow-up-right-from-square"></i>
+      </div>
+    </div>
+    <VRow class="px-0 pb-0 ma-0">
       <VCol class="pa-0 ma-0" cols="6">
-        <VSheet class="px-4 pb-3 pt-3 ma-0 mr-1" color="layer1" style="border-radius: 8px">
+        <VSheet class="px-4 pb-3 pt-3 ma-0 mr-1 h-100" color="layer1" style="border-radius: 8px">
           <div class="d-flex justify-space-between align-center mb-4">
             <div class="text-text text-caption">{{ wxmTokenCardTotalText }}</div>
+            <TooltipComponent
+              :tooltip-title="wxmTokenCardTotalSupplyTooltipTitle"
+              :message="wxmTokenCardTotalSupplyTooltipText"
+              container="any"
+            />
           </div>
           <div :style="responsiveTextStyles">
             {{ nFormat(props.wxmTokenTotalSupply) }}
@@ -75,22 +97,50 @@
       </VCol>
       <VCol class="pa-0 ma-0" cols="6">
         <VSheet class="px-4 pb-3 pt-3 ma-0 ml-1" color="layer1" style="border-radius: 8px">
-          <div class="d-flex justify-space-between align-center mb-4">
-            <div class="text-text text-caption">{{ wxmTokenCardMintedText }}</div>
+          <div
+            :class="
+              display.smAndDown
+                ? `d-flex justify-space-between align-start mb-4`
+                : `d-flex justify-space-between align-center mb-4`
+            "
+          >
+            <div class="text-text text-caption">
+              {{ wxmTokenCardCirculatingText }}
+            </div>
+            <TooltipComponent
+              :tooltip-title="wxmTokenCardCirculatingTooltipTitle"
+              :message="wxmTokenCardCirculatingTooltipText"
+              container="any"
+            />
           </div>
-          <div :style="responsiveTextStyles">{{ localizeNumber(props.wxmTokenDailyMinted) }}</div>
+          <div :style="responsiveTextStyles" class="mb-4">
+            {{ nFormat(props.wxmTokenDailyMinted) }}
+          </div>
+          <div>
+            <v-progress-linear
+              v-model="circulatingPercentage"
+              :style="{
+                backgroundColor: theme.current.colors.top
+              }"
+              :color="theme.current.dark ? `#2780FF4D` : `rgba(39, 128, 255, 0.30)`"
+              :rounded="true"
+            ></v-progress-linear>
+          </div>
         </VSheet>
       </VCol>
     </VRow>
   </VSheet>
 </template>
 
-<style lang="scss" scoped>
+<style lang="scss">
   a:link {
     color: var(--anchor-color);
   }
 
   a:visited {
     color: var(--anchor-color);
+  }
+  .v-progress-linear__determinate {
+    border-radius: 4px !important;
   }
 </style>

--- a/components/Stats/widgets/WXMToken.vue
+++ b/components/Stats/widgets/WXMToken.vue
@@ -69,15 +69,13 @@
 
     <div
       class="mb-3 text-primary font-weight-black d-flex align-center"
-      style="cursor: pointer"
-      @click="
-        trackGAevent('click_on_token_contract_link'),
-          navigateTo(wxmTokenSubtitleLink, { open: { target: '_blank' } })
-      "
+      @click="trackGAevent('click_on_token_contract_link')"
       @mouseenter="trackGAevent('click_on_token_contract_link')"
     >
-      <span class="pl-2 pr-1">{{ wxmTokenSubtitleLinkText }}</span>
-      <i class="fa-solid fa-arrow-up-right-from-square"></i>
+      <a :href="wxmTokenSubtitleLink" target="_blank" class="text-decoration-none">
+        <span class="pl-2 pr-1">{{ wxmTokenSubtitleLinkText }}</span>
+        <i class="fa-solid fa-arrow-up-right-from-square"></i
+      ></a>
     </div>
 
     <VRow class="px-0 pb-0 ma-0">

--- a/components/Stats/widgets/WXMToken.vue
+++ b/components/Stats/widgets/WXMToken.vue
@@ -24,7 +24,7 @@
   const wxmTokenCardCirculatingText = ref('CIRCULATING SUPPLY')
   const wxmTokenSubtitleLinkText = ref('View token contract on Etherscan')
   const wxmTokenSubtitleLink = ref(
-    'https://etherscan.io/token/0xde654f497a563dd7a121c176a125dd2f11f13a83s'
+    'https://etherscan.io/token/0xde654f497a563dd7a121c176a125dd2f11f13a83'
   )
 
   const wxmTokenCardTotalSupplyTooltipTitle = ref('Total Supply')

--- a/components/Stats/widgets/WeatherStations.vue
+++ b/components/Stats/widgets/WeatherStations.vue
@@ -110,12 +110,19 @@
 </script>
 
 <template>
-  <VSheet color="top" style="border-radius: 16px" class="pb-2" elevation="4">
-    <VRow class="px-5 pt-3 pb-3 ma-0 align-center justify-space-between">
-      <div class="text-body-1" style="font-weight: 700">{{ weatherStationsCardTitle }}</div>
+  <VSheet
+    color="top"
+    style="border-radius: 16px"
+    elevation="4"
+    :class="display.smAndDown ? ` pa-2 mb-3` : ` pa-2 mb-4`"
+  >
+    <VRow class="px-2 mb-3 ma-0 pt-1 align-center justify-space-between">
+      <div class="text-body-1" style="font-weight: 700">
+        {{ weatherStationsCardTitle }}
+      </div>
     </VRow>
     <!----------  Total -------->
-    <VSheet class="mx-2 mb-2" color="layer1" style="border-radius: 8px">
+    <VSheet class="mb-2" color="layer1" style="border-radius: 8px">
       <VRow class="pa-0 ma-0 pb-3 pt-3 justify-space-between align-center">
         <div class="text-body-2 pl-3">{{ weatherStationsCardTotalSectionHeader }}</div>
         <div
@@ -184,7 +191,7 @@
       </VRow>
     </VSheet>
     <!----------  Claimed -------->
-    <VSheet class="mx-2 mb-2" color="layer1" style="border-radius: 8px">
+    <VSheet class="mb-2" color="layer1" style="border-radius: 8px">
       <VRow class="pa-0 ma-0 pb-3 pt-3 justify-space-between align-center">
         <div class="text-body-2 pl-3">{{ weatherStationsCardClaimedSectionHeader }}</div>
         <div
@@ -253,7 +260,7 @@
       </VRow>
     </VSheet>
     <!----------  Active -------->
-    <VSheet class="mx-2 mb-2" color="layer1" style="border-radius: 8px">
+    <VSheet color="layer1" style="border-radius: 8px">
       <VRow class="pa-0 ma-0 pb-3 pt-3 justify-space-between align-center">
         <div class="text-body-2 pl-3">{{ weatherStationsCardActiveSectionHeader }}</div>
         <div

--- a/components/common/TooltipComponent.vue
+++ b/components/common/TooltipComponent.vue
@@ -86,7 +86,9 @@
       :style="overlayColor"
     >
       <template #activator="{ props }">
-        <i class="fa-light fa-circle-info" :class="'text-text pa-1'" v-bind="props" />
+        <span style="font-size: 12px">
+          <i class="fa-light fa-circle-info" :class="'text-text pa-1'" v-bind="props" />
+        </span>
       </template>
       <div class="pt-1 pb-1 px-1 text-caption" :class="getTheme ? 'text-text' : 'text-top'">
         <span v-html="props.message" />

--- a/composables/useGAevents.ts
+++ b/composables/useGAevents.ts
@@ -127,6 +127,30 @@ export const useGAevents = () => {
       parameters: {
         ACTION_NAME: 'Device Observations Download Button '
       }
+    },
+    {
+      eventKey: 'click_on_reward_contract_link',
+      eventName: 'SELECT_CONTENT',
+      parameters: {
+        CONTENT_TYPE: 'Network Stats',
+        SOURCE: 'reward_contract'
+      }
+    },
+    {
+      eventKey: 'click_on_token_contract_link',
+      eventName: 'SELECT_CONTENT',
+      parameters: {
+        CONTENT_TYPE: 'Network Stats',
+        SOURCE: 'token_contract'
+      }
+    },
+    {
+      eventKey: 'click_on_reward_last_run',
+      eventName: 'SELECT_CONTENT',
+      parameters: {
+        CONTENT_TYPE: 'Network Stats',
+        SOURCE: 'last_run_hash'
+      }
     }
   ]
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wxm-explorer",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": true,
   "scripts": {
     "build": "nuxt build",


### PR DESCRIPTION
Added mainnet banner in network stats and made it clickable
Added rewards and token links to arbiscan and etherscan respectively 
Feractored token card (add circulating and progress bar(mocked)) 
Made Last run clickable (mocked)
Added info buttons on Circulating supply and Total Supply 
Added analytics on info buttons and token/rewards links

Linear Issue : https://linear.app/weatherxm/issue/FE-859/network-stats-sidebar-changes-in-web-explorer