### PR TITLE
[FE-1062] add dynamic env selection on deploy on dev machine workflow

### DIFF
--- a/.github/workflows/deploy_dev_machine.yaml
+++ b/.github/workflows/deploy_dev_machine.yaml
@@ -3,10 +3,11 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - "staging"
+      - 'staging'
 jobs:
   build:
     runs-on: [self-hosted]
+    environment: ${{ github.event.inputs.environment }}
     steps:
       - uses: actions/checkout@v3
       - name: Prepare environment


### PR DESCRIPTION
### The purpose of this PR is to update the current GitHub workflows to accept a dynamic selection.
- It basically means add support for which env file is taken into account for the `Deploy on Dev machine` workflow.
- This allows for easier testing and adjustments without editing the single env file we had before (also used for production)