### PR TITLE
Fixed workflow to trigger actual event for env selection on dispatch

### DIFF
--- a/.github/workflows/deploy_dev_machine.yaml
+++ b/.github/workflows/deploy_dev_machine.yaml
@@ -1,6 +1,12 @@
 name: Deploy on Dev
 on:
   workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to target'
+        type: environment
+        required: true
+        default: 'development'
   push:
     tags:
       - 'staging'


### PR DESCRIPTION
Added the trigger that was missing from the deploy on dev workflow to actually trigger the GH event to show the env selection option when choosing this workflow